### PR TITLE
Switch to arma_cerr_stream<T>

### DIFF
--- a/src/vssGeneral.cpp
+++ b/src/vssGeneral.cpp
@@ -221,7 +221,7 @@ double vOptimiser(arma::mat const &matrixY, arma::mat &matrixV, arma::mat const 
     // arma::mat const &matrixX, arma::mat &matrixA, arma::mat const &matrixFX, arma::mat const &matrixGX,
     // # Make decomposition functions shut up!
     std::ostream nullstream(0);
-    arma::set_cerr_stream(nullstream);
+    arma::arma_cerr_stream<char>(&nullstream);
 
     arma::uvec nonzeroes = find(matrixO>0);
     int obs = nonzeroes.n_rows;


### PR DESCRIPTION
Armadillo updates its coding convention over time.  We have been fairly hard at work to have RcppArmadillo-using packages switch from a now-deprecated older way of instantiatig variables to a newer one (see [issue #391 for details](https://github.com/RcppCore/RcppArmadillo/issues/391)).

When compiling packages using RcppArmadillo with the deprecation-warning-suppressor we still use, some new warnings come up.  One concerns a deprecated way of setting an output or error stream as package legion does in one.  Changing this is fairly straightforward, and affects only that one one line.  

The package passes its tests with the change as it did before.

It would be much appreciated if you could apply this pull request and update the package at CRAN within the next few months. Let me know if you have any questions.